### PR TITLE
feat: implement TypeScript executor 

### DIFF
--- a/packages/ts-executor/package-lock.json
+++ b/packages/ts-executor/package-lock.json
@@ -1,0 +1,152 @@
+{
+  "name": "@webrunnr/ts-executor",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@webrunnr/ts-executor",
+      "version": "1.0.0",
+      "dependencies": {
+        "@babel/standalone": "^7.28.2"
+      },
+      "devDependencies": {
+        "@types/babel__standalone": "^7.1.9",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/standalone": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.28.2.tgz",
+      "integrity": "sha512-1kjA8XzBRN68HoDDYKP38bucHtxYWCIX8XdYwe1drRNUOjOVNt8EMy9jiE6UwaGFfU7NOHCG+C8KgBc9CR08nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__standalone": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/@types/babel__standalone/-/babel__standalone-7.1.9.tgz",
+      "integrity": "sha512-IcCNPLqpevUD7UpV8QB0uwQPOyoOKACFf0YtYWRHcmxcakaje4Q7dbG2+jMqxw/I8Zk0NHvEps66WwS7z/UaaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.6",
+        "@babel/types": "^7.25.6",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__generator": "^7.6.8",
+        "@types/babel__template": "^7.4.4",
+        "@types/babel__traverse": "^7.20.6"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/ts-executor/package.json
+++ b/packages/ts-executor/package.json
@@ -2,15 +2,18 @@
   "name": "@webrunnr/ts-executor",
   "version": "1.0.0",
   "description": "TypeScript code executor for WebRunnr",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
-    "test": "echo \"No tests specified\""
+    "test": "node test-executor.mjs"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@babel/standalone": "^7.28.2"
+  },
   "devDependencies": {
     "typescript": "^5.0.0"
   },

--- a/packages/ts-executor/src/babel-standalone.d.ts
+++ b/packages/ts-executor/src/babel-standalone.d.ts
@@ -1,0 +1,14 @@
+// Type declarations for @babel/standalone
+declare module '@babel/standalone' {
+  interface TransformOptions {
+    presets?: any[];
+    filename?: string;
+  }
+
+  interface TransformResult {
+    code: string;
+  }
+
+  export function transform(code: string, options: TransformOptions): TransformResult;
+  export default any;
+}

--- a/packages/ts-executor/src/compile.ts
+++ b/packages/ts-executor/src/compile.ts
@@ -1,0 +1,117 @@
+
+import {
+  CompilerOptions,
+  CompilationResult,
+  CompilationError,
+} from './types.js';
+
+export class TypeScriptCompiler {
+  private defaultOptions: CompilerOptions = {
+    target: 'es2020',
+    module: 'es2020',
+    lib: ['es2020', 'dom'],
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+  };
+
+   
+  private async getBabel() {
+    // Check if we're in browser with global Babel
+    if (typeof window !== 'undefined' && (window as any).Babel) {
+      return (window as any).Babel;
+    }
+
+    // Node.js environment - use dynamic import
+    const BabelModule = await import('@babel/standalone');
+    return BabelModule.default || BabelModule;
+  }
+
+
+  public async compile(
+    tsCode: string,
+    options?: CompilerOptions
+  ): Promise<CompilationResult> {
+    try {
+      const mergedOptions = { ...this.defaultOptions, ...options };
+
+      // Basic TypeScript error detection 
+      const typeErrors = this.detectBasicTypeErrors(tsCode);
+      if (typeErrors.length > 0) {
+        return {
+          success: false,
+          errors: typeErrors,
+        };
+      }
+
+      const Babel = await this.getBabel();
+
+      // Configure Babel with TypeScript compilation
+      const result = Babel.transform(tsCode, {
+        presets: [
+          [
+            'typescript',
+            {
+              allExtensions: true,
+              allowDeclareFields: true,
+            },
+          ],
+        ],
+        filename: 'input.ts',
+      });
+
+      if (!result || !result.code) {
+        return {
+          success: false,
+          errors: [
+            {
+              message: 'Compilation failed: No output generated',
+            },
+          ],
+        };
+      }
+
+      return {
+        success: true,
+        code: result.code,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        errors: this.parseCompilationError(error),
+      };
+    }
+  }
+
+  //Parses compilation errors from Babel
+   
+  private parseCompilationError(error: any): CompilationError[] {
+    const errors: CompilationError[] = [];
+
+    if (error.message) {
+      errors.push({
+        message: error.message,
+        line: error.loc?.line,
+        column: error.loc?.column,
+      });
+    } else {
+      errors.push({
+        message: 'Unknown compilation error',
+      });
+    }
+
+    return errors;
+  }
+
+  
+  private detectBasicTypeErrors(code: string): CompilationError[] {
+    const errors: CompilationError[] = [];
+
+    // Very basic error detection 
+    // For now, just return empty array (no error detection)
+
+    return errors;
+  }
+}
+
+export default TypeScriptCompiler;

--- a/packages/ts-executor/src/index.ts
+++ b/packages/ts-executor/src/index.ts
@@ -1,18 +1,85 @@
-// TypeScript executor - Handles TypeScript code execution
+/**
+ * TypeScript Executor - Main class for executing TypeScript code
+ * Focuses on TypeScript compilation to JavaScript
+ */
+
+import { TypeScriptCompiler } from './compile.js';
+import { ExecutionRequest, ExecutionResult, CompilerOptions } from './types.js';
+
 export class TypeScriptExecutor {
+  private compiler: TypeScriptCompiler;
+
   constructor() {
-    // Initialize TypeScript executor
+    this.compiler = new TypeScriptCompiler();
   }
 
-  initialize(): void {
-    // TODO: Setup postMessage communication with core
-    // TODO: Setup sandboxed execution environment with TypeScript compiler
+  /**
+   * Initializes the TypeScript executor
+   */
+  public initialize(): void {
+    // Initialization complete
   }
 
-  private executeCode(code: string): void {
-    // TODO: Implement TypeScript code execution logic
-    // TODO: Compile TypeScript to JavaScript then execute
+  /**
+   * Compiles TypeScript code without executing it
+   * @param code - TypeScript code to compile
+   * @param options - Compiler options
+   * @returns Compilation result
+   */
+  public async compileOnly(code: string, options?: CompilerOptions) {
+    return await this.compiler.compile(code, options);
+  }
+
+  /**
+   * Executes TypeScript code by compiling it to JavaScript
+   * Note: JavaScript execution will be handled by separate JS executor
+   * @param request - Execution request containing code and options
+   * @returns Promise with execution result
+   */
+  public async execute(request: ExecutionRequest): Promise<ExecutionResult> {
+    try {
+      // Basic validation - check if code is empty
+      if (!request.code.trim()) {
+        return {
+          stdout: '',
+          stderr: 'Error: Code cannot be empty',
+        };
+      }
+
+      // Compile TypeScript to JavaScript
+      const compilationResult = await this.compiler.compile(
+        request.code,
+        request.options
+      );
+
+      if (!compilationResult.success || !compilationResult.code) {
+        const errorMessage = compilationResult.errors
+          ? compilationResult.errors.map(e => e.message).join('\n')
+          : 'Unknown compilation error';
+
+        return {
+          stdout: '',
+          stderr: `Compilation failed:\n${errorMessage}`,
+          compilationErrors: compilationResult.errors,
+        };
+      }
+
+      // Return compiled JavaScript (execution will be handled separately)
+      return {
+        stdout: `Successfully compiled to JavaScript:\n\n${compilationResult.code}`,
+        stderr: '',
+      };
+    } catch (error) {
+      return {
+        stdout: '',
+        stderr: `Compilation error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
   }
 }
+
+// Export types for external use
+export * from './types.js';
+export { TypeScriptCompiler } from './compile.js';
 
 export default TypeScriptExecutor;

--- a/packages/ts-executor/src/types.ts
+++ b/packages/ts-executor/src/types.ts
@@ -1,0 +1,39 @@
+/**
+ * TypeScript Executor Types
+ * Defines interfaces and types for TypeScript compilation and execution
+ */
+
+export interface CompilerOptions {
+  target?: string;
+  module?: string;
+  lib?: string[];
+  strict?: boolean;
+  esModuleInterop?: boolean;
+  skipLibCheck?: boolean;
+}
+
+export interface CompilationResult {
+  success: boolean;
+  code?: string;
+  errors?: CompilationError[];
+}
+
+export interface CompilationError {
+  message: string;
+  line?: number;
+  column?: number;
+}
+
+export interface ExecutionRequest {
+  code: string;
+  options?: CompilerOptions;
+}
+
+export interface ExecutionResult {
+  stdout: string;
+  stderr: string;
+  compilationErrors?: CompilationError[];
+}
+
+// Dummy export to ensure this file generates a .js file
+export const VERSION = '1.0.0';

--- a/packages/ts-executor/test-playground.html
+++ b/packages/ts-executor/test-playground.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TypeScript Executor Test Playground</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            border-bottom: 2px solid #007acc;
+            padding-bottom: 10px;
+        }
+        h3 {
+            color: #555;
+            margin-top: 20px;
+            padding: 8px 12px;
+            background-color: #f0f0f0;
+            border-radius: 4px;
+            border-left: 4px solid #007acc;
+        }
+        .code-section {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            margin: 20px 0;
+        }
+        .code-panel {
+            display: flex;
+            flex-direction: column;
+        }
+        textarea {
+            width: 100%;
+            height: 300px;
+            font-family: 'Courier New', monospace;
+            font-size: 13px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 10px;
+            resize: vertical;
+            background-color: #fafafa;
+        }
+        .single-column {
+            grid-column: 1 / -1;
+        }
+        .single-column textarea {
+            height: 200px;
+        }
+        button {
+            background-color: #007acc;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+            font-size: 14px;
+        }
+        button:hover {
+            background-color: #005a9e;
+        }
+        .output {
+            background-color: #f8f8f8;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 10px;
+            font-family: 'Courier New', monospace;
+            font-size: 12px;
+            white-space: pre-wrap;
+            min-height: 60px;
+            max-height: 200px;
+            overflow-y: auto;
+        }
+        .error-output {
+            background-color: #ffeaea;
+            border-color: #ff6b6b;
+            color: #d63031;
+        }
+        .success-output {
+            background-color: #eafaf1;
+            border-color: #00b894;
+            color: #00b894;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>TypeScript Executor Test Playground</h1>
+        <p>Compare TypeScript code with its compiled JavaScript output!</p>
+        
+        <div class="code-section">
+            <div class="code-panel">
+                <h3>TypeScript Input</h3>
+                <textarea id="tsCode" placeholder="Enter your TypeScript code here...">// TypeScript with interfaces, generics, and type annotations
+interface User {
+    id: number;
+    name: string;
+    email: string;
+    isActive?: boolean;
+}
+
+// Generic function
+function createUser<T extends User>(userData: T): T {
+    return {
+        ...userData,
+        isActive: userData.isActive ?? true
+    };
+}
+
+// Union types
+type Status = "pending" | "approved" | "rejected";
+
+// Class with private fields and methods
+class UserManager {
+    private users: User[] = [];
+    
+    public addUser(user: User): void {
+        this.users.push(user);
+        console.log(`Added user: ${user.name}`);
+    }
+    
+    public getActiveUsers(): User[] {
+        return this.users.filter(user => user.isActive);
+    }
+}
+
+// Using the code
+const manager = new UserManager();
+const newUser = createUser<User>({
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com"
+});
+
+manager.addUser(newUser);
+
+// Type assertions and optional chaining
+const status: Status = "approved";
+console.log(`User status: ${status}`);</textarea>
+            </div>
+            
+            <div class="code-panel">
+                <h3>Compiled JavaScript Output</h3>
+                <div id="jsOutput" class="output" style="height: 300px; overflow-y: auto;"></div>
+            </div>
+        </div>
+        
+        <div style="text-align: center; margin: 20px 0;">
+            <button onclick="compileCode()">Compile TypeScript</button>
+            <button onclick="clearAll()">Clear All</button>
+        </div>
+        
+        <div class="single-column">
+            <h3>Messages</h3>
+            <div id="errorOutput" class="output error-output"></div>
+        </div>
+    </div>
+
+    <!-- Load Babel from CDN for browser testing -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    
+    <script type="module">
+        console.log('Starting TypeScript Executor Playground...');
+        
+        // Check if Babel loaded
+        if (window.Babel) {
+            console.log('Babel loaded successfully');
+        } else {
+            console.error('Babel not loaded!');
+        }
+        
+        // Import our TypeScript executor
+        try {
+            const TypeScriptExecutorModule = await import('./dist/index.js');
+            const TypeScriptExecutor = TypeScriptExecutorModule.default;
+            console.log('Module imported successfully');
+            
+            // Create global instance
+            window.tsExecutor = new TypeScriptExecutor();
+            await window.tsExecutor.initialize();
+            console.log('TypeScript Executor initialized');
+            
+        } catch (error) {
+            console.error('Failed to import or initialize executor:', error);
+            document.getElementById('errorOutput').textContent = `Module loading failed: ${error.message}`;
+        }
+        
+        // Test functions
+        window.compileCode = async () => {
+            try {
+                if (!window.tsExecutor) {
+                    throw new Error('TypeScript Executor not initialized');
+                }
+                
+                console.log('Starting compilation...');
+                const code = document.getElementById('tsCode').value;
+                console.log('Input code length:', code.length);
+                
+                const result = await window.tsExecutor.compileOnly(code);
+                console.log('Compilation result:', result);
+                
+                if (result.success) {
+                    document.getElementById('jsOutput').textContent = result.code;
+                    document.getElementById('errorOutput').textContent = '';
+                    console.log('Compilation successful! Output length:', result.code?.length);
+                } else {
+                    document.getElementById('jsOutput').textContent = '';
+                    document.getElementById('errorOutput').textContent = result.errors?.map(e => `Line ${e.line}: ${e.message}`).join('\n') || 'Unknown error';
+                    console.log('Compilation failed:', result.errors);
+                }
+                
+                // Clear any previous messages
+                document.getElementById('errorOutput').textContent = '';
+            } catch (error) {
+                console.error('Error in compileCode:', error);
+                document.getElementById('errorOutput').textContent = `Error: ${error.message}`;
+                document.getElementById('jsOutput').textContent = '';
+            }
+        };
+        
+        window.clearAll = () => {
+            document.getElementById('jsOutput').textContent = '';
+            document.getElementById('errorOutput').textContent = '';
+        };
+        
+        console.log('TypeScript Executor Test Playground Ready!');
+    </script>
+</body>
+</html>

--- a/packages/ts-executor/tsconfig.json
+++ b/packages/ts-executor/tsconfig.json
@@ -8,17 +8,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmitOnError": true,
-    "incremental": true,
-    "composite": true
+    "lib": ["ES2022", "DOM"],
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
- Add TypeScript compilation using @babel/standalone
- Support browser and Node.js environments
- Add browser testing playground